### PR TITLE
Fix AES cipher padding parameter

### DIFF
--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/AesAlgorithm.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/AesAlgorithm.java
@@ -44,7 +44,7 @@ public final class AesAlgorithm implements Algorithm {
     private static final Charset charset = StandardCharsets.UTF_8;
 
     private Cipher getUninitializedCipher() throws NoSuchAlgorithmException, NoSuchPaddingException {
-        return Cipher.getInstance("AES/GCM/PKCS5Padding");
+        return Cipher.getInstance("AES/GCM/NoPadding");
     }
 
     @Override


### PR DESCRIPTION
AES GCM mode does not use padding, so the cipher
String of "AES/GCM/PKCS5Padding" does not make sense.
Instead, it should be "AES/GCM/NoPadding". JDK 8 accepted
both forms and they operate the same, but using the correct
form is more portable.
