### PR TITLE
Making the error messages clearer when decryption fails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 .idea/
 out/
 generated_src/
+generated_testSrc
 
 # Codegen
 .generated

--- a/encrypted-config-value-bundle/src/main/java/com/palantir/config/crypto/ConfigurationDecryptionException.java
+++ b/encrypted-config-value-bundle/src/main/java/com/palantir/config/crypto/ConfigurationDecryptionException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto;
+
+import io.dropwizard.configuration.ConfigurationException;
+import java.util.Collection;
+
+public class ConfigurationDecryptionException extends ConfigurationException {
+    private static final long serialVersionUID = 1L;
+
+    public ConfigurationDecryptionException(String path, Collection<String> errors, Throwable cause) {
+        super(path, errors, cause);
+    }
+}

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/SubstitutingConfigurationFactoryTest.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/SubstitutingConfigurationFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+import com.palantir.config.crypto.jackson.JsonNodeStringReplacer;
+import com.palantir.config.crypto.util.Person;
+import com.palantir.config.crypto.util.TestConfig;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import java.io.File;
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SubstitutingConfigurationFactoryTest {
+    private static String previousProperty;
+    private static SubstitutingConfigurationFactory<TestConfig> factory;
+
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        previousProperty = System.getProperty(KeyPair.KEY_PATH_PROPERTY);
+        System.setProperty(KeyPair.KEY_PATH_PROPERTY, "src/test/resources/test.key");
+
+        factory = new SubstitutingConfigurationFactory<TestConfig>(
+                TestConfig.class,
+                Validators.newValidator(),
+                Jackson.newObjectMapper(),
+                "",
+                new JsonNodeStringReplacer(new DecryptingVariableSubstitutor()));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (previousProperty != null) {
+            System.setProperty(KeyPair.KEY_PATH_PROPERTY, previousProperty);
+        }
+    }
+
+    @Test
+    public final void decryptionSucceeds() throws IOException, ConfigurationException {
+        TestConfig config = factory.build(new File("src/test/resources/testConfig.yml"));
+
+        assertThat(config.getEncrypted()).isEqualTo("value");
+        assertThat(config.getUnencrypted()).isEqualTo("value");
+        assertThat(config.getEncryptedWithSingleQuote()).isEqualTo("don't use quotes");
+        assertThat(config.getEncryptedWithDoubleQuote()).isEqualTo("double quote is \"");
+        assertThat(config.getEncryptedMalformedYaml()).isEqualTo("[oh dear");
+        assertThat(config.getArrayWithSomeEncryptedValues())
+                .containsExactly("value", "value", "other value", "[oh dear");
+        assertThat(config.getPojoWithEncryptedValues()).isEqualTo(Person.of("some-user", "value"));
+
+
+    }
+
+    @Test
+    public final void decryptionFailsWithNiceMessage() throws IOException, ConfigurationException {
+        try {
+            factory.build(new File("src/test/resources/testConfigWithError.yml"));
+            failBecauseExceptionWasNotThrown(ConfigurationDecryptionException.class);
+        } catch (ConfigurationDecryptionException e) {
+            assertThat(e.getMessage()).contains("src/test/resources/testConfigWithError.yml has an error");
+            assertThat(e.getMessage()).contains(
+                    "The value 'enc:ERROR' for field 'arrayWithSomeEncryptedValues[3]' could not be replaced");
+        }
+    }
+}

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/VariableSubstitutionTest.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/VariableSubstitutionTest.java
@@ -23,17 +23,12 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.config.crypto.util.TestConfig;
 import io.dropwizard.Application;
-import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.io.IOException;
-import java.util.List;
-import org.immutables.value.Value;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -60,70 +55,6 @@ public final class VariableSubstitutionTest {
         assertThat(RULE.getConfiguration().getPojoWithEncryptedValues(),
                 both(hasProperty("username", equalTo("some-user")))
                 .and(hasProperty("password", equalTo("value"))));
-    }
-
-    @Value.Immutable
-    @JsonSerialize(as = ImmutablePerson.class)
-    @JsonDeserialize(as = ImmutablePerson.class)
-    public interface Person {
-        String getUsername();
-
-        String getPassword();
-    }
-
-    public static final class TestConfig extends Configuration {
-        private final String unencrypted;
-        private final String encrypted;
-        private final String encryptedWithSingleQuote;
-        private final String encryptedWithDoubleQuote;
-        private final String encryptedMalformedYaml;
-        private final List<String> arrayWithSomeEncryptedValues;
-        private final Person pojoWithEncryptedValues;
-
-        public TestConfig(
-                @JsonProperty("unencrypted") String unencrypted,
-                @JsonProperty("encrypted") String encrypted,
-                @JsonProperty("encryptedWithSingleQuote") String encryptedWithSingleQuote,
-                @JsonProperty("encryptedWithDoubleQuote") String encryptedWithDoubleQuote,
-                @JsonProperty("encryptedMalformedYaml") String encryptedMalformedYaml,
-                @JsonProperty("arrayWithSomeEncryptedValues") List<String> arrayWithSomeEncryptedValues,
-                @JsonProperty("pojoWithEncryptedValues") Person pojoWithEncryptedValues) {
-            this.unencrypted = unencrypted;
-            this.encrypted = encrypted;
-            this.encryptedWithSingleQuote = encryptedWithSingleQuote;
-            this.encryptedWithDoubleQuote = encryptedWithDoubleQuote;
-            this.encryptedMalformedYaml = encryptedMalformedYaml;
-            this.arrayWithSomeEncryptedValues = arrayWithSomeEncryptedValues;
-            this.pojoWithEncryptedValues = pojoWithEncryptedValues;
-        }
-
-        public String getUnencrypted() {
-            return unencrypted;
-        }
-
-        public String getEncrypted() {
-            return encrypted;
-        }
-
-        public String getEncryptedWithSingleQuote() {
-            return encryptedWithSingleQuote;
-        }
-
-        public String getEncryptedWithDoubleQuote() {
-            return encryptedWithDoubleQuote;
-        }
-
-        public String getEncryptedMalformedYaml() {
-            return encryptedMalformedYaml;
-        }
-
-        public List<String> getArrayWithSomeEncryptedValues() {
-            return arrayWithSomeEncryptedValues;
-        }
-
-        public Person getPojoWithEncryptedValues() {
-            return pojoWithEncryptedValues;
-        }
     }
 
     public static final class TestApplication extends Application<TestConfig> {

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/jackson/JsonNodeStringReplacerTest.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/jackson/JsonNodeStringReplacerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.POJONode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.config.crypto.util.StringSubstitutionException;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JsonNodeStringReplacerTest {
+    @Mock
+    private StrSubstitutor strSubstitutor;
+    @Mock
+    private Throwable cause;
+
+    private JsonNodeStringReplacer jsonNodeStringReplacer;
+
+    @Before
+    public final void setUp() {
+        jsonNodeStringReplacer = new JsonNodeStringReplacer(strSubstitutor);
+    }
+
+    @Test
+    public final void visitTextDelegatesToStrSubstitutor() {
+        TextNode textNode = new TextNode("abc");
+        when(strSubstitutor.replace("abc")).thenReturn("def");
+        assertThat(jsonNodeStringReplacer.visitText(textNode)).isEqualTo(new TextNode("def"));
+    }
+
+    @Test
+    public final void visitArrayDispatchesToChildren() {
+        ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.instance);
+        arrayNode.add("abc");
+        arrayNode.add(1);
+
+        when(strSubstitutor.replace("abc")).thenReturn("def");
+
+        ArrayNode expected = new ArrayNode(JsonNodeFactory.instance);
+        expected.add("def");
+        expected.add(1);
+
+        assertThat(jsonNodeStringReplacer.visitArray(arrayNode)).isEqualTo(expected);
+    }
+
+    @Test
+    public final void visitArrayExtendsStringSubstitutionException() {
+        ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.instance);
+        arrayNode.add(1);
+        arrayNode.add(2);
+        arrayNode.add(new ObjectNode(
+                JsonNodeFactory.instance,
+                ImmutableMap.<String, JsonNode>of("key", new TextNode("abc"))));
+        arrayNode.add(4);
+
+        doThrow(new StringSubstitutionException(cause, "abc")).when(strSubstitutor).replace("abc");
+
+        try {
+            jsonNodeStringReplacer.visitArray(arrayNode);
+            failBecauseExceptionWasNotThrown(StringSubstitutionException.class);
+        } catch (StringSubstitutionException e) {
+            assertThat(e.getValue()).isEqualTo("abc");
+            assertThat(e.getField()).isEqualTo("[2].key");
+        }
+    }
+
+    @Test
+    public final void visitObjectDispatchesToChildren() {
+        ObjectNode objectNode = new ObjectNode(
+                JsonNodeFactory.instance,
+                ImmutableMap.<String, JsonNode>of(
+                        "key1", new TextNode("abc"),
+                        "key2", new IntNode(1)));
+
+        when(strSubstitutor.replace("abc")).thenReturn("def");
+
+        ObjectNode expected = new ObjectNode(
+                JsonNodeFactory.instance,
+                ImmutableMap.<String, JsonNode>of(
+                        "key1", new TextNode("def"),
+                        "key2", new IntNode(1)));
+
+        assertThat(jsonNodeStringReplacer.visitObject(objectNode)).isEqualTo(expected);
+    }
+
+    @Test
+    public final void visitObjectExtendsStringSubstitutionException() {
+        ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.instance);
+        arrayNode.add(1);
+        arrayNode.add(2);
+        arrayNode.add(new ObjectNode(
+                JsonNodeFactory.instance,
+                ImmutableMap.<String, JsonNode>of("key", new TextNode("abc"))));
+        arrayNode.add(4);
+
+        ObjectNode objectNode = new ObjectNode(
+                JsonNodeFactory.instance,
+                ImmutableMap.<String, JsonNode>of(
+                        "key1", new IntNode(1),
+                        "key2", arrayNode));
+
+        doThrow(new StringSubstitutionException(cause, "abc")).when(strSubstitutor).replace("abc");
+
+        try {
+            jsonNodeStringReplacer.visitObject(objectNode);
+            failBecauseExceptionWasNotThrown(StringSubstitutionException.class);
+        } catch (StringSubstitutionException e) {
+            assertThat(e.getValue()).isEqualTo("abc");
+            assertThat(e.getField()).isEqualTo("key2[2].key");
+        }
+    }
+
+    @Test
+    public final void visitBinaryPassesThrough() {
+        BinaryNode binaryNode = mock(BinaryNode.class);
+        assertThat(jsonNodeStringReplacer.visitBinary(binaryNode)).isEqualTo(binaryNode);
+    }
+
+    @Test
+    public final void visitBooleanPassesThrough() {
+        BooleanNode booleanNode = mock(BooleanNode.class);
+        assertThat(jsonNodeStringReplacer.visitBoolean(booleanNode)).isEqualTo(booleanNode);
+    }
+
+    @Test
+    public final void visitNumericPassesThrough() {
+        NumericNode numericNode = mock(NumericNode.class);
+        assertThat(jsonNodeStringReplacer.visitNumeric(numericNode)).isEqualTo(numericNode);
+    }
+
+    @Test
+    public final void visitPojoPassesThrough() {
+        POJONode pojoNode = mock(POJONode.class);
+        assertThat(jsonNodeStringReplacer.visitPojo(pojoNode)).isEqualTo(pojoNode);
+    }
+
+    @Test
+    public final void visitNullReturnsNullNodeInstance() {
+        assertThat(jsonNodeStringReplacer.visitNull()).isEqualTo(NullNode.getInstance());
+    }
+
+    @Test
+    public final void visitMissingReturnsMissingNodeInstance() {
+        assertThat(jsonNodeStringReplacer.visitMissing()).isEqualTo(MissingNode.getInstance());
+    }
+}

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/util/Person.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/util/Person.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.util;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutablePerson.class)
+@JsonDeserialize(as = ImmutablePerson.class)
+public abstract class Person {
+    @Value.Parameter
+    public abstract String getUsername();
+
+    @Value.Parameter
+    public abstract String getPassword();
+
+    public static Person of(String username, String password) {
+        return ImmutablePerson.of(username, password);
+    }
+}

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/util/TestConfig.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/util/TestConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Configuration;
+import java.util.List;
+
+public final class TestConfig extends Configuration {
+    private final String unencrypted;
+    private final String encrypted;
+    private final String encryptedWithSingleQuote;
+    private final String encryptedWithDoubleQuote;
+    private final String encryptedMalformedYaml;
+    private final List<String> arrayWithSomeEncryptedValues;
+    private final Person pojoWithEncryptedValues;
+
+    public TestConfig(
+            @JsonProperty("unencrypted") String unencrypted,
+            @JsonProperty("encrypted") String encrypted,
+            @JsonProperty("encryptedWithSingleQuote") String encryptedWithSingleQuote,
+            @JsonProperty("encryptedWithDoubleQuote") String encryptedWithDoubleQuote,
+            @JsonProperty("encryptedMalformedYaml") String encryptedMalformedYaml,
+            @JsonProperty("arrayWithSomeEncryptedValues") List<String> arrayWithSomeEncryptedValues,
+            @JsonProperty("pojoWithEncryptedValues") Person pojoWithEncryptedValues) {
+        this.unencrypted = unencrypted;
+        this.encrypted = encrypted;
+        this.encryptedWithSingleQuote = encryptedWithSingleQuote;
+        this.encryptedWithDoubleQuote = encryptedWithDoubleQuote;
+        this.encryptedMalformedYaml = encryptedMalformedYaml;
+        this.arrayWithSomeEncryptedValues = arrayWithSomeEncryptedValues;
+        this.pojoWithEncryptedValues = pojoWithEncryptedValues;
+    }
+
+    public String getUnencrypted() {
+        return unencrypted;
+    }
+
+    public String getEncrypted() {
+        return encrypted;
+    }
+
+    public String getEncryptedWithSingleQuote() {
+        return encryptedWithSingleQuote;
+    }
+
+    public String getEncryptedWithDoubleQuote() {
+        return encryptedWithDoubleQuote;
+    }
+
+    public String getEncryptedMalformedYaml() {
+        return encryptedMalformedYaml;
+    }
+
+    public List<String> getArrayWithSomeEncryptedValues() {
+        return arrayWithSomeEncryptedValues;
+    }
+
+    public Person getPojoWithEncryptedValues() {
+        return pojoWithEncryptedValues;
+    }
+}

--- a/encrypted-config-value-bundle/src/test/resources/testConfigWithError.yml
+++ b/encrypted-config-value-bundle/src/test/resources/testConfigWithError.yml
@@ -1,0 +1,13 @@
+unencrypted: value
+encrypted: ${enc:INNv4cGkVF45MLWZhgVZdIsgQ4zKvbMoJ978Es3MIKgrtz5eeTuOCLM1vPbQm97ejz2EK6M=}
+encryptedWithSingleQuote: ${enc:NcsMVEFTDL7mpCDlHe3aMPriDohAnTbmy/Eh3Ix2KC1hibsuFYFuU0X7a9CqAiLZHCGfAth0i8kzBOji7yRxpQ==}
+encryptedWithDoubleQuote: ${enc:CfaCBbD7T1rcTe0LhLt34n77pHwx8R4IPx5XoPDcJirRqRMfsrc/ngd+vd5AJItNu56UQagYnVqHuRWZIhGC0s4=}
+encryptedMalformedYaml: ${enc:edhPbHr7h2sFrTiCBzOpltIKDboXHqiEhsLSeYAdmxGJdXe+safSnDmZxCLQm5tADUkYgWZqHF8=}
+arrayWithSomeEncryptedValues:
+  - ${enc:INNv4cGkVF45MLWZhgVZdIsgQ4zKvbMoJ978Es3MIKgrtz5eeTuOCLM1vPbQm97ejz2EK6M=}
+  - value
+  - other value
+  - ${enc:ERROR}
+pojoWithEncryptedValues:
+  username: some-user
+  password: ${enc:INNv4cGkVF45MLWZhgVZdIsgQ4zKvbMoJ978Es3MIKgrtz5eeTuOCLM1vPbQm97ejz2EK6M=}

--- a/encrypted-config-value/build.gradle
+++ b/encrypted-config-value/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testCompile libs.hamcrest
     testCompile libs.junit
+    testCompile libs.mockito
     testRuntime libs.bouncycastle
 
     processor libs.immutables

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/DecryptingVariableSubstitutor.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/DecryptingVariableSubstitutor.java
@@ -16,6 +16,7 @@
 
 package com.palantir.config.crypto;
 
+import com.palantir.config.crypto.util.StringSubstitutionException;
 import org.apache.commons.lang3.text.StrLookup;
 import org.apache.commons.lang3.text.StrSubstitutor;
 
@@ -28,7 +29,11 @@ public final class DecryptingVariableSubstitutor extends StrSubstitutor {
     private static final class DecryptingStringLookup extends StrLookup<String> {
         @Override
         public String lookup(String encryptedValue) {
-            return EncryptedValue.of(encryptedValue).getDecryptedValue();
+            try {
+                return EncryptedValue.of(encryptedValue).getDecryptedValue();
+            } catch (RuntimeException e) {
+                throw new StringSubstitutionException(e, encryptedValue);
+            }
         }
     }
 }

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/util/StringSubstitutionException.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/util/StringSubstitutionException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.util;
+
+public class StringSubstitutionException extends RuntimeException {
+    private final String value;
+    private final StringBuilder fieldBuilder;
+    private final boolean lastExtensionWasArrayIndex;
+
+    private StringSubstitutionException(
+            Throwable cause,
+            String value,
+            StringBuilder fieldBuilder,
+            boolean lastExtensionWasArrayIndex) {
+        super(cause);
+        this.value = value;
+        this.fieldBuilder = fieldBuilder;
+        this.lastExtensionWasArrayIndex = lastExtensionWasArrayIndex;
+    }
+
+    public StringSubstitutionException(Throwable cause, String value) {
+        this(cause, value, new StringBuilder(), false);
+    }
+
+    public final StringSubstitutionException extend(String field) {
+        return extend(field, false);
+    }
+
+    public final StringSubstitutionException extend(int arrayIndex) {
+        return extend("[" + arrayIndex + "]", true);
+    }
+
+    private StringSubstitutionException extend(String prefix, boolean prefixIsArrayIndex) {
+        StringBuilder extendedFieldBuilder = new StringBuilder(prefix);
+        if (fieldBuilder.length() > 0 && !lastExtensionWasArrayIndex) {
+            extendedFieldBuilder.append(".");
+        }
+        extendedFieldBuilder.append(fieldBuilder);
+        return new StringSubstitutionException(getCause(), value, extendedFieldBuilder, prefixIsArrayIndex);
+    }
+
+    public final String getField() {
+        return fieldBuilder.toString();
+    }
+
+    public final String getValue() {
+        return value;
+    }
+}

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/DecryptingVariableSubstitutorTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/DecryptingVariableSubstitutorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.palantir.config.crypto.algorithm.Algorithm;
+import com.palantir.config.crypto.algorithm.Algorithms;
+import com.palantir.config.crypto.util.StringSubstitutionException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DecryptingVariableSubstitutorTest {
+    private static final Algorithm ALGORITHM = Algorithms.getInstance("RSA");
+    private static final KeyPair KEY_PAIR = ALGORITHM.generateKey();
+    private static String previousProperty;
+
+    private final DecryptingVariableSubstitutor substitutor = new DecryptingVariableSubstitutor();
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        previousProperty = System.getProperty(KeyPair.KEY_PATH_PROPERTY);
+
+        Path tempFilePath = Files.createTempDirectory("temp-key-directory").resolve("test.key");
+        KEY_PAIR.toFile(tempFilePath);
+        System.setProperty(KeyPair.KEY_PATH_PROPERTY, tempFilePath.toAbsolutePath().toString());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (previousProperty != null) {
+            System.setProperty(KeyPair.KEY_PATH_PROPERTY, previousProperty);
+        }
+    }
+
+    @Test
+    public final void constantsAreNotModified() {
+        assertThat(substitutor.replace("abc"), is("abc"));
+    }
+
+    @Test
+    public final void invalidVariablesThrowStringSubstitutionException() {
+        try {
+            substitutor.replace("${abc}");
+            fail();
+        } catch (StringSubstitutionException e) {
+            assertThat(e.getValue(), is("abc"));
+            assertThat(e.getField(), is(""));
+        }
+    }
+
+    @Test
+    public final void variableIsDecrypted() throws Exception {
+        assertThat(substitutor.replace("${enc:" + encrypt("abc") + "}"), is("abc"));
+    }
+
+    private String encrypt(String value) {
+        return ALGORITHM.getEncryptedValue(value, KEY_PAIR.publicKey()).encryptedValue();
+    }
+}

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/util/StringSubstitutionExceptionTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/util/StringSubstitutionExceptionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StringSubstitutionExceptionTest {
+    private static final String VALUE = "abc";
+
+    @Mock
+    private Throwable cause;
+
+    @Test
+    public final void testConstructions() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception, "");
+    }
+
+    @Test
+    public final void testSingleExtendField() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend("field1"), "field1");
+    }
+
+    @Test
+    public final void testDoubleExtendField() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend("field1").extend("field2"), "field2.field1");
+    }
+
+    @Test
+    public final void testSingleExtendArray() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend(1), "[1]");
+    }
+
+    @Test
+    public final void testDoubleExtendArray() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend(1).extend(2), "[2][1]");
+    }
+
+    @Test
+    public final void testSingleExtendArrayAndField() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend(1).extend("field"), "field[1]");
+    }
+
+    @Test
+    public final void testSingleExtendArrayAndDoubleField() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend(1).extend("field1").extend("field2"), "field2.field1[1]");
+    }
+
+    @Test
+    public final void testSingleExtendArrayBetweenDoubleField() {
+        StringSubstitutionException exception = new StringSubstitutionException(cause, VALUE);
+        assertException(exception.extend("field1").extend(1).extend("field2"), "field2[1].field1");
+    }
+
+    private void assertException(StringSubstitutionException exception, String field) {
+        assertThat(exception.getValue(), is(VALUE));
+        assertThat(exception.getField(), is(field));
+        assertThat(exception.getCause(), is(cause));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,8 @@ jaxRsVersion=2.0.1
 jsr305Version=3.0.0
 slf4jVersion=1.7.12
 
+# testCompile
+mockitoVersion=1.10.19
+
 # processors
 immutablesVersion=2.0.21

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -19,6 +19,7 @@ project.ext.libs = [
     ],
     'jsr305': 'com.google.code.findbugs:jsr305:3.0.0',
     'junit': 'junit:junit:4.12',
+    'mockito': "org.mockito:mockito-core:${mockitoVersion}",
     'mockwebserver': 'com.squareup.okhttp:mockwebserver:2.5.0',
     'slf4j': 'org.slf4j:slf4j-api:1.7.12',
     'wsRsApi': 'javax.ws.rs:javax.ws.rs-api:2.0.1',


### PR DESCRIPTION
This is accomplished with a StringSubstitutionException that can be recursively extended
