### PR TITLE
Add error message when unable to replace encrypted value

### DIFF
--- a/encrypted-config-value-bundle/src/main/java/com/palantir/config/crypto/SubstitutingConfigurationFactory.java
+++ b/encrypted-config-value-bundle/src/main/java/com/palantir/config/crypto/SubstitutingConfigurationFactory.java
@@ -75,10 +75,11 @@ public final class SubstitutingConfigurationFactory<T> extends ConfigurationFact
             return super.build(substitutedNode, path);
         } catch (StringSubstitutionException e) {
             String error = String.format(
-                    "The value '%s' for field '%s' could not be replaced",
+                    "The value '%s' for field '%s' could not be replaced with its unencrypted value",
                     e.getValue(),
                     e.getField());
-            throw new ConfigurationDecryptionException(path, ImmutableList.of(error), e);
+            String underlyingError = String.format("Underlying error - %s", e.getMessage());
+            throw new ConfigurationDecryptionException(path, ImmutableList.of(error, underlyingError), e);
         }
     }
 

--- a/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/SubstitutingConfigurationFactoryTest.java
+++ b/encrypted-config-value-bundle/src/test/java/com/palantir/config/crypto/SubstitutingConfigurationFactoryTest.java
@@ -78,9 +78,12 @@ public class SubstitutingConfigurationFactoryTest {
             factory.build(new File("src/test/resources/testConfigWithError.yml"));
             failBecauseExceptionWasNotThrown(ConfigurationDecryptionException.class);
         } catch (ConfigurationDecryptionException e) {
-            assertThat(e.getMessage()).contains("src/test/resources/testConfigWithError.yml has an error");
+            assertThat(e.getMessage()).contains("src/test/resources/testConfigWithError.yml has the following errors");
             assertThat(e.getMessage()).contains(
-                    "The value 'enc:ERROR' for field 'arrayWithSomeEncryptedValues[3]' could not be replaced");
+                    "The value 'enc:ERROR' for field 'arrayWithSomeEncryptedValues[3]' could not be replaced "
+                    + "with its unencrypted value");
+            assertThat(e.getMessage()).contains(
+                    "Underlying error - ");
         }
     }
 }


### PR DESCRIPTION
Don't swallow the message from the underlying runtime exceptions. Example new messages:

```
/opt/palantir/services/foundry-stack~multipass~2820/var/conf/multipass.yml has the following errors:
  * The value 'enc:RIKuq4pFW3Z5Yx7FQXzDzLJQywl6jABDrQs83rS6mxCfIjXw2Dioc9khkObwZFuEevh9HfLia3ht85mcSnCkWBQwViRo/jsf' for field 'token.privateKeyEncryptionSecret' could not be replaced with its unencrypted value.
  * Underlying error - java.lang.RuntimeException: Was unable to read key
```

```
com.palantir.config.crypto.ConfigurationDecryptionException: src/test/resources/testConfig.yml has the following errors:
  * The value 'enc:INNv4cGkVF45MLWZhgVZdIsgQ4zKvbMoJ978Es3MIKgrtz5eeTuOCLM1vPbQm97ejz2EK6M=' for field 'encrypted' could not be replaced with its unencrypted value.
  * Underlying error - java.lang.RuntimeException: there was not a provider for the given algorithm
```
