### PR TITLE
Don't try to decrypt values that obviously are not encrypted

### DIFF
--- a/encrypted-config-value-module/src/main/java/com/palantir/config/crypto/DecryptingVariableSubstitutor.java
+++ b/encrypted-config-value-module/src/main/java/com/palantir/config/crypto/DecryptingVariableSubstitutor.java
@@ -29,6 +29,10 @@ public final class DecryptingVariableSubstitutor extends StrSubstitutor {
     private static final class DecryptingStringLookup extends StrLookup<String> {
         @Override
         public String lookup(String encryptedValue) {
+            if (!EncryptedValue.isEncryptedValue(encryptedValue)) {
+                return null;
+            }
+
             try {
                 return EncryptedValue.of(encryptedValue).getDecryptedValue();
             } catch (RuntimeException e) {

--- a/encrypted-config-value-module/src/test/java/com/palantir/config/crypto/DecryptingVariableSubstitutorTest.java
+++ b/encrypted-config-value-module/src/test/java/com/palantir/config/crypto/DecryptingVariableSubstitutorTest.java
@@ -31,6 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class DecryptingVariableSubstitutorTest {
+
     private static final Algorithm ALGORITHM = Algorithms.getInstance("RSA");
     private static final KeyPair KEY_PAIR = ALGORITHM.generateKey();
     private static String previousProperty;
@@ -59,14 +60,19 @@ public class DecryptingVariableSubstitutorTest {
     }
 
     @Test
-    public final void invalidVariablesThrowStringSubstitutionException() {
+    public final void invalidEncryptedVariablesThrowStringSubstitutionException() {
         try {
-            substitutor.replace("${abc}");
+            substitutor.replace("${enc:invalid-contents}");
             fail();
         } catch (StringSubstitutionException e) {
-            assertThat(e.getValue(), is("abc"));
+            assertThat(e.getValue(), is("enc:invalid-contents"));
             assertThat(e.getField(), is(""));
         }
+    }
+
+    @Test
+    public final void nonEncryptedVariablesAreNotModified() {
+        assertThat(substitutor.replace("${abc}"), is("${abc}"));
     }
 
     @Test

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/EncryptedValue.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/EncryptedValue.java
@@ -61,12 +61,16 @@ public abstract class EncryptedValue {
         return PREFIX + encryptedValue();
     }
 
+    public static boolean isEncryptedValue(String encryptedValue) {
+        return encryptedValue.startsWith(PREFIX);
+    }
+
     /**
      * @param encryptedValue - a string of the form "prefix:encrypted-string-in-base-64".
      * @return an EncryptedConfigValue for this encrypted string
      */
     public static EncryptedValue of(String encryptedValue) {
-        checkArgument(encryptedValue.startsWith(PREFIX),
+        checkArgument(isEncryptedValue(encryptedValue),
                 "encrypted value must begin with %s but is %s", PREFIX, encryptedValue);
         return fromEncryptedString(encryptedValue.substring(PREFIX.length()));
     }


### PR DESCRIPTION
StrSubstitutor supports ignoring unknown variables.
Apply this logic to allow further substitutions by applications.