### PR TITLE
Add JCE Unlimited Strength policy files to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ machine:
     version: oraclejdk8
   environment:
     TERM: dumb
+  post:
+    # install JCE Unlimited Strength Jurisdiction Policy Files
+    - |
+      wget -qO- --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip" | bsdtar -xvf- -C /tmp && sudo cp /tmp/UnlimitedJCEPolicyJDK8/* $JAVA_HOME/jre/lib/security/
 
 general:
   artifacts:


### PR DESCRIPTION
Ensures that all of the tests can be run correctly. AES should
always use keys of at least 256 bits, so better to make the test
environment support this rather than using weakers keys just for
the purposes of tests.