### PR TITLE
Remove unnecessary style annotations

### DIFF
--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/aes/AesEncryptedValue.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/aes/AesEncryptedValue.java
@@ -34,7 +34,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableAesEncryptedValue.class)
 @JsonSerialize(as = AesEncryptedValue.class)
-@Value.Style(additionalJsonAnnotations = JsonSerialize.class)
 public abstract class AesEncryptedValue extends EncryptedValue {
     public enum Mode {
         GCM,

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaEncryptedValue.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaEncryptedValue.java
@@ -37,7 +37,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableRsaEncryptedValue.class)
 @JsonSerialize(as = RsaEncryptedValue.class)
-@Value.Style(additionalJsonAnnotations = JsonSerialize.class)
 public abstract class RsaEncryptedValue extends EncryptedValue {
 
     public enum Mode {


### PR DESCRIPTION
Fixes #71 

The annotations which cause the warning are actually no longer necessary. See https://github.com/immutables/immutables/blob/immutables-2.4.4/value/src/org/immutables/value/Value.java#L780