### PR TITLE
add a circle2 workflow to trigger builds on tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,3 +32,12 @@ jobs:
           if [[ $TAG =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
             ./gradlew -i bintrayUpload
           fi
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          filters:
+            # run on all branches and tags
+            tags:
+              only: /.*/


### PR DESCRIPTION
circle2 builds were not triggering on tag releases

https://circleci.com/docs/2.0/workflows/#git-tag-job-execution