### PR TITLE
Implement equals, hashCode for AesKey, RsaPrivateKey and RsaPublicKey

### DIFF
--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/aes/AesKey.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/aes/AesKey.java
@@ -42,6 +42,25 @@ public final class AesKey implements Key {
         return secretKey.getEncoded();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final AesKey other = (AesKey) obj;
+        return secretKey.equals(other.getSecretKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return secretKey.hashCode();
+    }
+
     @Immutable
     public enum AesKeyGenerator implements KeyGenerator {
         INSTANCE;

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaPrivateKey.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaPrivateKey.java
@@ -46,6 +46,25 @@ public final class RsaPrivateKey implements Key {
         return privateKey.getEncoded();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final RsaPrivateKey other = (RsaPrivateKey) obj;
+        return privateKey.equals(other.getPrivateKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return privateKey.hashCode();
+    }
+
     @Immutable
     public enum RsaPrivateKeyGenerator implements KeyGenerator {
         INSTANCE;

--- a/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaPublicKey.java
+++ b/encrypted-config-value/src/main/java/com/palantir/config/crypto/algorithm/rsa/RsaPublicKey.java
@@ -46,6 +46,25 @@ public final class RsaPublicKey implements Key {
         return publicKey.getEncoded();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final RsaPublicKey other = (RsaPublicKey) obj;
+        return publicKey.equals(other.getPublicKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return publicKey.hashCode();
+    }
+
     @Immutable
     public enum RsaPublicKeyGenerator implements KeyGenerator {
         INSTANCE;

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/KeyWithTypeTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/KeyWithTypeTest.java
@@ -24,17 +24,24 @@ import org.junit.jupiter.api.Test;
 
 public final class KeyWithTypeTest {
     private static final ObjectMapper mapper = new ObjectMapper();
-    private static final String kwtString = "AES:rqrvWpLld+wKLOyxJYxQVg==";
-    private static final KeyWithType kwt = KeyWithType.fromString(kwtString);
+    private static final String KWT_STRING = "AES:rqrvWpLld+wKLOyxJYxQVg==";
+    private static final KeyWithType KWT = KeyWithType.fromString(KWT_STRING);
 
     @Test
     public void testSerialization() throws IOException {
-        String serialized = mapper.writeValueAsString(kwt);
+        String serialized = mapper.writeValueAsString(KWT);
 
-        String expectedSerialization = String.format("\"%s\"", kwtString);
+        String expectedSerialization = String.format("\"%s\"", KWT_STRING);
         assertThat(serialized).isEqualTo(expectedSerialization);
 
         KeyWithType deserialized = mapper.readValue(serialized, KeyWithType.class);
-        assertThat(deserialized.toString()).isEqualTo(kwt.toString());
+        assertThat(deserialized.toString()).isEqualTo(KWT.toString());
+    }
+
+    @Test
+    public void testEqualityFromSameString() {
+        KeyWithType kwt1 = KeyWithType.fromString(KWT_STRING);
+        KeyWithType kwt2 = KeyWithType.fromString(KWT_STRING);
+        assertThat(kwt1).isEqualTo(kwt2);
     }
 }

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/aes/AesKeyTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/aes/AesKeyTest.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.algorithm.aes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.config.crypto.algorithm.Algorithm;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+public class AesKeyTest {
+    public static SecretKey newSecretKey() {
+        javax.crypto.KeyGenerator keyGen;
+        try {
+            keyGen = javax.crypto.KeyGenerator.getInstance(Algorithm.AES.toString());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        keyGen.init(128);
+        return keyGen.generateKey();
+    }
+
+    @Test
+    public void testEqualityFromSameSecretKey() {
+        SecretKey secretKey = newSecretKey();
+        assertThat(new AesKey(secretKey)).isEqualTo(new AesKey(secretKey));
+    }
+}

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/rsa/RsaPrivateKeyTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/rsa/RsaPrivateKeyTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.algorithm.rsa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.config.crypto.algorithm.Algorithm;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import org.junit.jupiter.api.Test;
+
+public class RsaPrivateKeyTest {
+
+    private static KeyPair generateKeyPair() {
+        KeyPairGenerator keyPairGenerator;
+        try {
+            keyPairGenerator = KeyPairGenerator.getInstance(Algorithm.RSA.toString());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    @Test
+    public void testEqualityFromSamePrivateKey() {
+        PrivateKey privateKey = generateKeyPair().getPrivate();
+        assertThat(new RsaPrivateKey(privateKey)).isEqualTo(new RsaPrivateKey(privateKey));
+    }
+}

--- a/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/rsa/RsaPublicKeyTest.java
+++ b/encrypted-config-value/src/test/java/com/palantir/config/crypto/algorithm/rsa/RsaPublicKeyTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.crypto.algorithm.rsa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.config.crypto.algorithm.Algorithm;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import org.junit.jupiter.api.Test;
+
+public class RsaPublicKeyTest {
+    private static KeyPair generateKeyPair() {
+        KeyPairGenerator keyPairGenerator;
+        try {
+            keyPairGenerator = KeyPairGenerator.getInstance(Algorithm.RSA.toString());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    @Test
+    public void testEqualityFromSamePublicKey() {
+        PublicKey publicKey = generateKeyPair().getPublic();
+        assertThat(new RsaPublicKey(publicKey)).isEqualTo(new RsaPublicKey(publicKey));
+    }
+}


### PR DESCRIPTION
Fixes #91. These changes are inspired by @ash211's changes here [408](https://github.com/palantir/encrypted-config-value/pull/408). However, this approach implements `equals` and `hashCode` for the concrete keys rather than refactoring them to `Immutable`s.

@nmiyake if you would prefer that this is implemented at `KeyWithType` let me know. The current implementation seems quite clean since we can just leverage the equality exposed by the underlying implementations.

## Before this PR

Checking equality between keys did not work as expected. See [408](https://github.com/palantir/encrypted-config-value/pull/408) for further context.

## After this PR

Two keys will correctly report as equal if they have the same underlying values.
==COMMIT_MSG==
Implement equals, hashCode for AesKey, RsaPrivateKey and RsaPublicKey
==COMMIT_MSG==

## Possible downsides?

None that I can currently forsee.

